### PR TITLE
updated to the atom-workspace tag

### DIFF
--- a/keymaps/turbo-javascript.cson
+++ b/keymaps/turbo-javascript.cson
@@ -7,6 +7,6 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace':
+'atom-workspace':
   'ctrl-;': 'turbo-javascript:end-line'
   'ctrl-enter': 'turbo-javascript:end-new-line'


### PR DESCRIPTION
the .workspace class is deprecated, updated to the atom-workspace tag.