### PR TITLE
Arrow function "af" and "afb" snippet parentheses

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,12 +184,12 @@ ${1:fn}.bind(${2:this}, ${3:arguments})
 
 #### `af⇥` arrow function (ES6)
 ```js
-${1:(arguments)} => ${2:statement}
+(${1:arguments}) => ${2:statement}
 ```
 
 #### `afb⇥` arrow function with body (ES6)
 ```js
-${1:(arguments)} => {
+(${1:arguments}) => {
 \t${0}
 }
 ```

--- a/snippets/functions.cson
+++ b/snippets/functions.cson
@@ -34,12 +34,12 @@
   "arrow function":
     prefix: "af"
     body: """
-    ${1:(arguments)} => ${2:statement}
+    (${1:arguments}) => ${2:statement}
     """
   "arrow function with body":
     prefix: "afb"
     body: """
-    ${1:(arguments)} => {
+    (${1:arguments}) => {
     \t${0}
     }
     """


### PR DESCRIPTION
We want the parentheses in the final arrow function but right now the snippet is written in a way that removes them.