### PR TITLE
Push parenthesis for "af" and "afb" snippets out of substitution.

### DIFF
--- a/snippets/functions.cson
+++ b/snippets/functions.cson
@@ -34,12 +34,12 @@
   "arrow function":
     prefix: "af"
     body: """
-    ${1:(arguments)} => ${2:statement}
+    (${1:arguments}) => ${2:statement}
     """
   "arrow function with body":
     prefix: "afb"
     body: """
-    ${1:(arguments)} => {
+    (${1:arguments}) => {
     \t${0}
     }
     """


### PR DESCRIPTION
This way a user has the dummy "arguments" text selected so its easier to
replace or delete before moving on to the statement or body.