### PR TITLE
add context block to bdd.cson

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,12 @@ describe('${1:description}', function () {
   ${0}
 });
 ```
+#### `cont⇥` describe
+```js
+context('${1:description}', function () {
+  ${0}
+});
+```
 #### `its⇥` synchronous "it"
 ```js
 it('${1:description}', function () {

--- a/snippets/bdd.cson
+++ b/snippets/bdd.cson
@@ -6,6 +6,13 @@
     \t${0}
     });
     """
+  "context":
+    prefix: "cont"
+    body: """
+    context('${1:description}', () => {
+    \t${0}
+    });
+    """
   "it":
     prefix: "it"
     body: """


### PR DESCRIPTION
Adds a `context` snippet for Mocha;s BDD snippets. 