### PR TITLE
Add TypeScript (.tsx) snippets

### DIFF
--- a/snippets/async.cson
+++ b/snippets/async.cson
@@ -1,4 +1,4 @@
-".source.js, .source.ts":
+".source.js, .source.ts, .source.tsx":
   "Node callback":
     prefix: "cb"
     body: "function (err, ${1:value}) {${0}}"

--- a/snippets/bdd.cson
+++ b/snippets/bdd.cson
@@ -1,4 +1,4 @@
-".source.js, .source.ts":
+".source.js, .source.ts, .source.tsx":
   "describe":
     prefix: "desc"
     body: """

--- a/snippets/classes.cson
+++ b/snippets/classes.cson
@@ -1,4 +1,4 @@
-".source.js, .source.ts":
+".source.js, .source.ts, .source.tsx":
   "class":
     prefix: "c"
     body: """

--- a/snippets/console.cson
+++ b/snippets/console.cson
@@ -1,4 +1,4 @@
-".source.js, .source.ts":
+".source.js, .source.ts, .source.tsx":
   "console.log":
     prefix: "cl"
     body: "console.log(${0})"

--- a/snippets/declarations.cson
+++ b/snippets/declarations.cson
@@ -1,4 +1,4 @@
-".source.js, .source.ts":
+".source.js, .source.ts, .source.tsx":
   "var statement":
     prefix: "v"
     body: "var ${1:name}"

--- a/snippets/dom.cson
+++ b/snippets/dom.cson
@@ -1,4 +1,4 @@
-".source.js, .source.ts":
+".source.js, .source.ts, .source.tsx":
   "addEventListener":
     prefix: "ae"
     body: """

--- a/snippets/flow-control.cson
+++ b/snippets/flow-control.cson
@@ -1,4 +1,4 @@
-".source.js, .source.ts":
+".source.js, .source.ts, .source.tsx":
   "if statement":
     prefix: "if"
     body: """

--- a/snippets/functions.cson
+++ b/snippets/functions.cson
@@ -1,4 +1,4 @@
-".source.js, .source.ts":
+".source.js, .source.ts, .source.tsx":
   "anonymous function":
     prefix: "f"
     body: "function (${1:arguments}) {${0}}"

--- a/snippets/iterables.cson
+++ b/snippets/iterables.cson
@@ -1,4 +1,4 @@
-".source.js, .source.ts":
+".source.js, .source.ts, .source.tsx":
   "sequence":
     prefix: "seq"
     body: """

--- a/snippets/misc.cson
+++ b/snippets/misc.cson
@@ -1,4 +1,4 @@
-".source.js, .source.ts":
+".source.js, .source.ts, .source.tsx":
   "use strict":
     prefix: "us"
     body: "'use strict';"

--- a/snippets/modules.cson
+++ b/snippets/modules.cson
@@ -1,4 +1,4 @@
-".source.js, .source.ts":
+".source.js, .source.ts, .source.tsx":
   "module export":
     prefix: "ex"
     body: "export ${1:member};"

--- a/snippets/node-assert.cson
+++ b/snippets/node-assert.cson
@@ -1,4 +1,4 @@
-".source.js, .source.ts":
+".source.js, .source.ts, .source.tsx":
   "assert.equal":
     prefix: "ase"
     body: "assert.equal(${1:actual}, ${2:expected})"

--- a/snippets/node-events.cson
+++ b/snippets/node-events.cson
@@ -1,4 +1,4 @@
-".source.js, .source.ts":
+".source.js, .source.ts, .source.tsx":
   "event handler":
     prefix: "on"
     body: """

--- a/snippets/node-express.cson
+++ b/snippets/node-express.cson
@@ -1,4 +1,4 @@
-".source.js, .source.ts":
+".source.js, .source.ts, .source.tsx":
   "Express middleware":
     prefix: "xm"
     body: """

--- a/snippets/node-modules.cson
+++ b/snippets/node-modules.cson
@@ -1,4 +1,4 @@
-".source.js, .source.ts":
+".source.js, .source.ts, .source.tsx":
   "require":
     prefix: "re"
     body: "require('${1:module}')"

--- a/snippets/objects.cson
+++ b/snippets/objects.cson
@@ -1,4 +1,4 @@
-".source.js, .source.ts":
+".source.js, .source.ts, .source.tsx":
   "key/value pair":
     prefix: ":"
     body: "${1:key}: ${2:'value'}"

--- a/snippets/return.cson
+++ b/snippets/return.cson
@@ -1,4 +1,4 @@
-".source.js, .source.ts":
+".source.js, .source.ts, .source.tsx":
   "return":
     prefix: "r"
     body: "return ${0};"

--- a/snippets/timers.cson
+++ b/snippets/timers.cson
@@ -1,4 +1,4 @@
-".source.js, .source.ts":
+".source.js, .source.ts, .source.tsx":
   "setTimeout":
     prefix: "st"
     body: """

--- a/snippets/types.cson
+++ b/snippets/types.cson
@@ -1,4 +1,4 @@
-".source.js, .source.ts":
+".source.js, .source.ts, .source.tsx":
   "String":
     prefix: "S"
     body: "String"


### PR DESCRIPTION
Not long ago, we finally finished pull request adding these snippets to TypeScript. But these snippets still don't work within .tsx files, since the grammar is set differently, at least with atom-typescript, the most popular TypeScript plugin for atom. Adding `.source.tsx` next to `.source.js, .source.ts` fixes this. 