### PR TITLE
Removing braces for arrow function argument

### DIFF
--- a/snippets/functions.cson
+++ b/snippets/functions.cson
@@ -34,12 +34,12 @@
   "arrow function":
     prefix: "af"
     body: """
-    (${1:arguments}) => ${2:statement}
+    ${1:arguments} => ${2:statement}
     """
   "arrow function with body":
     prefix: "afb"
     body: """
-    (${1:arguments}) => {
+    ${1:arguments} => {
     \t${0}
     }
     """

--- a/snippets/iterables.cson
+++ b/snippets/iterables.cson
@@ -7,23 +7,23 @@
   "forEach loop":
     prefix: "fe"
     body: """
-    ${1:iterable}.forEach((${2:item}) => {
+    ${1:iterable}.forEach(${2:item} => {
     \t${0}
     });
     """
   "chain forEach":
     prefix: ".fe"
-    body: ".forEach((${1:item}) => {${0}})"
+    body: ".forEach(${1:item} => {${0}})"
   "map":
     prefix: "map"
     body: """
-    ${1:iterable}.map((${2:item}) => {
+    ${1:iterable}.map(${2:item} => {
     \t${0}
     });
     """
   "chain map":
     prefix: ".map"
-    body: ".map((${1:item}) => {${0}})"
+    body: ".map(${1:item} => {${0}})"
   "reduce":
     prefix: "reduce"
     body: """
@@ -37,20 +37,20 @@
   "filter":
     prefix: "filter"
     body: """
-    ${1:iterable}.filter((${2:item}) => {
+    ${1:iterable}.filter(${2:item} => {
     \t${0}
     });
     """
   "chain filter":
     prefix: ".filter"
-    body: ".filter((${1:item}) => {${0}})"
+    body: ".filter(${1:item} => {${0}})"
   "find":
     prefix: "find"
     body: """
-    ${1:iterable}.find((${2:item}) => {
+    ${1:iterable}.find(${2:item} => {
     \t${0}
     });
     """
   "chain find":
     prefix: ".find"
-    body: ".find((${1:item}) => {${0}})"
+    body: ".find(${1:item} => {${0}})"


### PR DESCRIPTION
Hello, I removed braces for arrow function arguments. The reason is that according to airbnb style guide, you should omit the braces if the arrow function has only one argument. I find myself writing much more one argument arrow functions, so I always had to remove the braces. Also, adding braces to multi argument arrow functions is easier than removing them from one argument functions.
