### PR TITLE
Destructuring assignment declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ let ${1:name}
 let ${1:name} = ${2:value}
 ```
 
+#### `l={⇥` destructuring let assignment
+```js
+let { ${1: name} } = ${2:value}
+```
+
 #### `co⇥` const statement
 ```js
 const ${1:name}
@@ -53,6 +58,11 @@ const ${1:name}
 #### `co=⇥` const assignment
 ```js
 const ${1:name} = ${2:value}
+```
+
+#### `co={⇥` destructuring const assignment
+```js
+const { ${1:name} } = ${2:value}
 ```
 
 ### Flow Control

--- a/snippets/declarations.cson
+++ b/snippets/declarations.cson
@@ -11,9 +11,15 @@
   "let assignment":
     prefix: "l="
     body: "let ${1:name} = ${2:value}"
+  "destructuring let assignment":
+    prefix: "l={"
+    body: "let { ${1: name} } = ${2:value}"
   "const statement":
     prefix: "co"
     body: "const ${1:name}"
   "const assignment":
     prefix: "co="
     body: "const ${1:name} = ${2:value}"
+  "destructuring const assignment":
+    prefix: "co={"
+    body: "const { ${1:name} } = ${2:value}"


### PR DESCRIPTION
@extrabacon 

`co={` is especially helpful in react.js, like

``` javascript
const { something, another } = this.props
```

And release a new version, please!