### PR TITLE
Clockworkpc proposed

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Terminates the current line with a colon or semicolon, followed with a new line.
 #### Easy Blocks `CTRL-B`
 Creates a statement block `{ ... }` with the selected text placed inside and properly indented. If the selection is already wrapped with a block, the block is removed and its content is unindented.
 
+#### HTML Ecape Blocks (EJS) `CTRL->`
+Creates an HTML escape block `<%= %>` with the selected text placed inside and properly spaced.  If the selection is already wrapped with an HTML escape block, the block is removed.
+
 ## Snippets
 
 Snippets are optimized to be short and easy to remember. Some snippets are "chainable" and render differently when preceded by a ".".

--- a/README.md~
+++ b/README.md~
@@ -18,7 +18,7 @@ Terminates the current line with a colon or semicolon, followed with a new line.
 Creates a statement block `{ ... }` with the selected text placed inside and properly indented. If the selection is already wrapped with a block, the block is removed and its content is unindented.
 
 #### HTML Ecape Blocks (EJS) `CTRL->`
-Creates an HTML escape block `<%= %>` with the selected text placed inside and properly spaced.  If the selection is already wrapped with an HTML escape block, the block is removed.  Doesn't work perfectly though.
+Creates an HTML escape block `<%= %>` with the selected text placed inside and properly spaced.  If the selection is already wrapped with an HTML escape block, the block is removed.
 
 ## Snippets
 

--- a/keymaps/turbo-javascript.cson
+++ b/keymaps/turbo-javascript.cson
@@ -9,7 +9,7 @@
 # https://atom.io/docs/latest/advanced/keymaps
 'atom-text-editor':
   'ctrl-;': 'turbo-javascript:end-line'
-  # 'ctrl-,': 'turbo-javascript:end-line-comma'
+  'ctrl-,': 'turbo-javascript:end-line-comma'
   'ctrl-enter': 'turbo-javascript:end-new-line'
   'ctrl-b': 'turbo-javascript:wrap-block'
   'ctrl->': 'turbo-javascript:html-escape'

--- a/keymaps/turbo-javascript.cson
+++ b/keymaps/turbo-javascript.cson
@@ -9,6 +9,7 @@
 # https://atom.io/docs/latest/advanced/keymaps
 'atom-text-editor':
   'ctrl-;': 'turbo-javascript:end-line'
-  'ctrl-,': 'turbo-javascript:end-line-comma'
+  # 'ctrl-,': 'turbo-javascript:end-line-comma'
   'ctrl-enter': 'turbo-javascript:end-new-line'
   'ctrl-b': 'turbo-javascript:wrap-block'
+  'ctrl->': 'turbo-javascript:html-escape'

--- a/menus/turbo-javascript.cson
+++ b/menus/turbo-javascript.cson
@@ -8,6 +8,7 @@
         {'label': 'End line with semicolon', 'command': 'turbo-javascript:end-line'}
         {'label': 'End line with comma', 'command': 'turbo-javascript:end-line-comma'}
         {'label': 'Insert or remove block', 'command': 'turbo-javascript:wrap-block'}
+        {'label': 'Insert or remove HTML escape block', 'command': 'turbo-javascript:html-escape'}
       ]
     ]
   }


### PR DESCRIPTION
I've been very happy with turbo javascripts, but I needed a keyboard shortcut for the HTML escape `<%= %>` which is a real pain to write out each time.  I couldn't work out how to make it remove the tags from a string that already has them though.  Hope you find this useful.